### PR TITLE
I've fixed the asyncio event loop conflict in `main.py`.

### DIFF
--- a/main.py
+++ b/main.py
@@ -852,7 +852,7 @@ async def check_all_monitored_pairs_job(context) -> None:
 
 # --- Main Bot Logic ---
 
-async def main() -> None:
+def main() -> None:
     """Start the telegram bot."""
     # Initialize MT5
     if not initialize_mt5():
@@ -916,7 +916,7 @@ async def main() -> None:
     logger.info("Scheduled monitoring job to run every 5 minutes.")
 
     # Start the Bot
-    await application.run_polling()
+    application.run_polling()
     logger.info("Bot has started successfully.")
 
     # Run the bot until the user presses Ctrl-C
@@ -930,4 +930,4 @@ async def main() -> None:
     # logger.info("MetaTrader 5 connection shut down.")
 
 if __name__ == '__main__':
-    asyncio.run(main())
+    main()


### PR DESCRIPTION
Your application was failing with a `RuntimeError: This event loop is already running` because `asyncio.run()` was used to call the main function, which in turn used `application.run_polling()`. This created a nested asyncio event loop.

To resolve the conflict, I refactored the application startup logic:
- The `main()` function is converted from an `async` function to a regular synchronous function.
- The blocking call `application.run_polling()` is now called directly without `await`.
- The script entry point in `if __name__ == '__main__':` now calls `main()` directly, removing the unnecessary `asyncio.run()`.

This is the standard approach for running a `python-telegram-bot` application and ensures the event loop is managed correctly by the library itself.